### PR TITLE
docs: scaffold MkDocs Material site + first upstream rewrite

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,62 @@
+name: docs
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install MkDocs Material
+        run: |
+          python -m pip install --upgrade pip
+          pip install mkdocs mkdocs-material
+
+      # --strict turns warnings (dead links, missing nav targets,
+      # broken anchors) into hard failures so the docs PR red-flags
+      # rot before it lands.
+      - name: Build docs (strict)
+        run: mkdocs build --strict
+
+      - name: Upload site artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    # Publish to GitHub Pages off master only.  PR builds verify
+    # the site builds; they don't push.
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ tests/.venv/
 __pycache__/
 .pytest_cache/
 reports/
+/site/

--- a/docs/configuration/bpq32-cfg-keywords.md
+++ b/docs/configuration/bpq32-cfg-keywords.md
@@ -1,0 +1,8 @@
+# Bpq32 cfg keywords
+
+!!! warning "Stub page"
+    This page is a placeholder pending the rewrite-from-upstream
+    work tracked in [docs/plan.md](../plan.md).  John Wiseman's
+    original docs cover this material at
+    <https://www.cantab.net/users/john.wiseman/Documents/>.
+

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -1,0 +1,8 @@
+# Reference
+
+!!! warning "Stub page"
+    This page is a placeholder pending the rewrite-from-upstream
+    work tracked in [docs/plan.md](../plan.md).  John Wiseman's
+    original docs cover this material at
+    <https://www.cantab.net/users/john.wiseman/Documents/>.
+

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,0 +1,87 @@
+# Getting started
+
+!!! warning "Stub page"
+    Pending rewrite from upstream
+    [BPQ32 Documents.htm][bpq32-docs] +
+    [LinBPQ install / build notes][bpq-installguide]
+    plus the build steps the integration suite uses.  Tracking
+    in [docs/plan.md](../plan.md).
+
+A self-contained walk from a clean Linux box to a node serving
+a telnet session and a working BBS — fact-checked against the
+integration suite that ships alongside this repo.
+
+## What to build
+
+Linbpq builds from C source in this repo into a single
+binary (`linbpq`).  The build dependencies on Debian/Ubuntu:
+
+```bash
+sudo apt install build-essential libpaho-mqtt-dev libjansson-dev \
+  libminiupnpc-dev libconfig-dev libpcap-dev zlib1g-dev
+```
+
+Then:
+
+```bash
+make
+```
+
+produces `./linbpq` plus a stack of intermediate `.o` files.
+
+(Mac is `make -f makefile_mac`; FreeBSD / NetBSD detected
+automatically by `uname -s`.)
+
+## Minimum viable cfg
+
+```ini
+SIMPLE=1
+NODECALL=N0CALL
+NODEALIAS=TEST
+LOCATOR=NONE
+
+PORT
+ ID=Telnet
+ DRIVER=Telnet
+ CONFIG
+ TCPPORT=8010
+ HTTPPORT=8080
+ MAXSESSIONS=10
+ USER=test,test,N0CALL,,SYSOP
+ENDPORT
+```
+
+Replace `N0CALL` with your callsign, `IO91WJ`-style locator if
+you have one (or `NONE`), and pick TCP/HTTP ports that are free.
+
+## First boot
+
+```bash
+./linbpq
+```
+
+You should see something like:
+
+```
+G8BPQ AX25 Packet Switch System Version 6.0.25.23 February 2026
+...
+Initialising Port 01     Telnet Server
+MQTT Enabled 0
+```
+
+…then a telnet client to localhost:8010 lands on the node prompt.
+
+## Next steps
+
+- [Configuration reference][config-ref] — every supported cfg
+  keyword
+- [Node prompt commands][node-commands] — what to type once
+  you're on the prompt
+- [Subsystems][subsystems] — when you're ready to enable BBS,
+  Chat, APRS
+
+[bpq32-docs]: https://www.cantab.net/users/john.wiseman/Documents/BPQ32%20Documents.htm
+[bpq-installguide]: https://www.cantab.net/users/john.wiseman/Documents/LinBPQ.htm
+[config-ref]: ../configuration/reference.md
+[node-commands]: ../node-commands.md
+[subsystems]: ../subsystems/index.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,87 @@
+# LinBPQ documentation
+
+!!! warning "AI-generated, in progress"
+    This site is being built up from John Wiseman G8BPQ's
+    upstream HTML documentation, reorganised around user journeys
+    and fact-checked against the binary plus the integration test
+    suite.  Expect rough edges and gaps until the rewrite project
+    completes — see the [plan][docsplan] for status.
+
+LinBPQ is a Linux/macOS port of John Wiseman's
+[BPQ32][bpq32upstream] amateur-radio packet switch.  It runs as a
+single long-lived daemon (`linbpq`) built from ~150 C source
+files, configured by a single `bpq32.cfg`.  In one binary it
+provides:
+
+- An AX.25 / NET/ROM packet switch
+- A BBS (BPQMail) with FBB inter-BBS forwarding
+- A real-time chat node
+- An APRS gateway with iGate uplink
+
+It speaks to radios over a long list of modems (KISS, Pactor
+families, ARDOP, VARA, FLDigi, MULTIPSK, WinRPR, HSMODEM) and to
+clients over Telnet, AGW, KISS-over-TCP, AX.25-over-UDP, NET/ROM-
+over-TCP, MQTT, and a JSON / SNMP / Winlink CMS family.
+
+## Where to start
+
+<div class="grid cards" markdown>
+
+- :material-rocket-launch: __[Getting started][getting-started]__
+
+    Stand a node up from a clean Linux box: build, minimal
+    `bpq32.cfg`, first telnet login, smoke-test the wire.
+
+- :material-cog: __[Configuration reference][config-ref]__
+
+    Every cfg keyword the parser accepts, what subsystem owns it,
+    cross-referenced to the source line that consumes it.
+
+- :material-application-cog: __[Subsystems][subsystems]__
+
+    BBS / mail, chat, APRS — what each does, how to enable it,
+    the relationship between cfg keywords and runtime commands.
+
+- :material-network: __[Protocols and interfaces][protocols]__
+
+    AX.25, NET/ROM, AX/IP-over-UDP, KISS, FBB forwarding,
+    Winlink CMS — the wire formats LinBPQ implements.
+
+- :material-console: __[Node prompt commands][node-commands]__
+
+    Reference for every command on the telnet node prompt.
+    Generated from `Cmd.c::COMMANDS[]`, fact-checked against
+    the integration suite.
+
+- :material-source-pull: __[Upstream documentation][upstream]__
+
+    John Wiseman's original HTML docs, with a per-page status
+    of "rewritten / partial / pending" against this site.
+
+</div>
+
+## Why a re-presentation
+
+[John Wiseman's docs][bpqdocs] are the authoritative source on
+LinBPQ's behaviour and have been kept up to date for two decades.
+What this site adds is *organisation by audience and task*: the
+upstream docs are arranged loosely as files-as-found, while this
+site groups material by what someone actually wants to do, with
+deep links into the source and tests.
+
+This is a re-presentation, not a fork.  The technical content is
+faithful to the upstream and we cite John's pages prominently.
+Where this site disagrees with the upstream, that's a bug in this
+site or a behaviour change in the binary that needs an issue
+filed — please open a [GitHub issue][issues].
+
+[bpq32upstream]: https://www.cantab.net/users/john.wiseman/Documents/BPQ32%20Documents.htm
+[bpqdocs]: https://www.cantab.net/users/john.wiseman/Documents/
+[getting-started]: getting-started/index.md
+[config-ref]: configuration/reference.md
+[subsystems]: subsystems/index.md
+[protocols]: protocols/index.md
+[node-commands]: node-commands.md
+[upstream]: project/upstream.md
+[docsplan]: plan.md
+[issues]: https://github.com/M0LTE/linbpq/issues

--- a/docs/node-commands.md
+++ b/docs/node-commands.md
@@ -9,7 +9,7 @@
 
 This is a reference for every command that can be entered at the LinBPQ /
 BPQ32 node prompt. It is generated from the dispatch table `COMMANDS[]` in
-[`Cmd.c`](../Cmd.c) and the individual command handlers in `Cmd.c`,
+[`Cmd.c`](https://github.com/M0LTE/linbpq/blob/master/Cmd.c) and the individual command handlers in `Cmd.c`,
 `IPCode.c`, `TelnetV6.c`, `RHP.c`, `APRSCode.c`, `AGWAPI.c` and
 `CommonCode.c`.
 

--- a/docs/project/contributing.md
+++ b/docs/project/contributing.md
@@ -1,0 +1,8 @@
+# Contributing
+
+!!! warning "Stub page"
+    This page is a placeholder pending the rewrite-from-upstream
+    work tracked in [docs/plan.md](../plan.md).  John Wiseman's
+    original docs cover this material at
+    <https://www.cantab.net/users/john.wiseman/Documents/>.
+

--- a/docs/project/upstream.md
+++ b/docs/project/upstream.md
@@ -1,0 +1,126 @@
+# Upstream documentation
+
+The authoritative documentation for BPQ32/LinBPQ is John
+Wiseman G8BPQ's collection at
+[www.cantab.net/users/john.wiseman/Documents][bpqdocs].
+This page lists every document linked from the upstream index
+and its rewrite status on this site.
+
+This site is a re-presentation of John's work, organised by user
+journey and fact-checked against the binary plus the integration
+test suite.  All technical content is faithful to upstream;
+where this site disagrees with upstream that's a bug here or a
+behaviour change in the binary that needs an issue filed.
+
+[bpqdocs]: https://www.cantab.net/users/john.wiseman/Documents/
+
+## Status legend
+
+- **Rewritten** — page has been converted to Markdown, fact-
+  checked, and lives in this site's nav.
+- **Partial** — some material is here but the rewrite isn't
+  complete.
+- **Pending** — not yet started; upstream link is the canonical
+  source meanwhile.
+
+## Index
+
+### Installation and quickstart
+
+| Upstream page | Status | This site |
+|---------------|--------|-----------|
+| [BPQ32 Installation][BPQ32-Installation] | Pending | — |
+| [BPQ Quickstart Guide (Ken KD6PGI)][Quickstart_Guide] | Pending | — |
+| [LinBPQ Installation][InstallingLINBPQ] | Partial | [Getting started](../getting-started/index.md) |
+
+[BPQ32-Installation]: https://www.cantab.net/users/john.wiseman/Documents/BPQ32%20Installation.htm
+[Quickstart_Guide]: https://www.cantab.net/users/john.wiseman/Documents/Quickstart_Guide.html
+[InstallingLINBPQ]: https://www.cantab.net/users/john.wiseman/Documents/InstallingLINBPQ.html
+
+### Configuration
+
+| Upstream page | Status | This site |
+|---------------|--------|-----------|
+| [BPQ32 Configuration File Description][BPQCFGFile] | Pending | [Reference](../configuration/reference.md) |
+| [BPQ32 RS232 Cabling][rs232-cabling] | Pending | — |
+
+[BPQCFGFile]: https://www.cantab.net/users/john.wiseman/Documents/BPQCFGFile.html
+[rs232-cabling]: https://www.cantab.net/users/john.wiseman/Documents/BPQ32%20RS232%20Cabling.htm
+
+### Subsystems
+
+| Upstream page | Status | This site |
+|---------------|--------|-----------|
+| [BPQ Mail Server][MailServer] | Pending | [BBS / Mail](../subsystems/bbsmail.md) |
+| [BPQ Mail Server Configuration][MailServerConfiguration] | Pending | [BBS / Mail](../subsystems/bbsmail.md) |
+| [BPQ Mail Server Mail Forwarding][Forwarding] | Pending | — |
+| [BPQ Mail and Chat Hints and Kinks][HintsandKinks] | Pending | — |
+| [Mail Forwarding to/from Winlink][RMSForwarding] | Pending | — |
+| [Winlink interworking changes][BBSAttachments] | Pending | — |
+| [BPQ Mail Server email Client Configuration][eMailClientConfiguration] | Pending | — |
+| [BPQ Mail Server email Gateway][ISPGateway] | Pending | — |
+| [BPQ Mail Server Changelog][BBSChangeLog] | Pending | — |
+| [BBS User Commands][BBSUserCommands] | Pending | [Node prompt commands](../node-commands.md) (overlaps) |
+| [APRS Digipeater/IGate][APRSDigiGate] | Pending | [APRS](../subsystems/aprs.md) |
+| [APRS Mapping and Messaging Application][BPQAPRS] | Pending | — |
+| [Guide to Chat Network Map System][BPQChatMap] | Pending | — |
+| [IP Gateway Feature][IPGateway] | Pending | — |
+
+[MailServer]: https://www.cantab.net/users/john.wiseman/Documents/MailServer.html
+[MailServerConfiguration]: https://www.cantab.net/users/john.wiseman/Documents/MailServerConfiguration.html
+[Forwarding]: https://www.cantab.net/users/john.wiseman/Documents/Forwarding.html
+[HintsandKinks]: https://www.cantab.net/users/john.wiseman/Documents/HintsandKinks.html
+[RMSForwarding]: https://www.cantab.net/users/john.wiseman/Documents/RMSForwarding.html
+[BBSAttachments]: https://www.cantab.net/users/john.wiseman/Documents/BBSAttachments.html
+[eMailClientConfiguration]: https://www.cantab.net/users/john.wiseman/Documents/eMailClientConfiguration.html
+[ISPGateway]: https://www.cantab.net/users/john.wiseman/Documents/ISPGateway.html
+[BBSChangeLog]: https://www.cantab.net/users/john.wiseman/Documents/BBSChangeLog.html
+[BBSUserCommands]: https://www.cantab.net/users/john.wiseman/Documents/BBSUserCommands.html
+[APRSDigiGate]: https://www.cantab.net/users/john.wiseman/Documents/APRSDigiGate.html
+[BPQAPRS]: https://www.cantab.net/users/john.wiseman/Documents/BPQAPRS.htm
+[BPQChatMap]: https://www.cantab.net/users/john.wiseman/Documents/BPQChatMap.htm
+[IPGateway]: https://www.cantab.net/users/john.wiseman/Documents/IPGateway.html
+
+### Protocols and interfaces
+
+| Upstream page | Status | This site |
+|---------------|--------|-----------|
+| [BPQAXIP Configuration][BPQAXIPConfiguration] | Rewritten | [AX/IP over UDP](../protocols/axip.md) |
+| [BPQtoAGW][BPQtoAGW] | Pending | — |
+| [BPQ Host Mode Emulator][BPQHostModeEmulator] | Pending | — |
+| [BPQ Ethernet][BPQEthernet] | Pending | — |
+| [BPQ Virtual Serial Port Driver][VirtualSerial] | Pending | — |
+| [Using Pactor with BPQ32][UsingPactor] | Pending | — |
+| [Using WINMOR with BPQ32][UsingWINMOR] | Pending | — |
+| [Airmail to WINMOR][AirmailtoWINMOR] | Pending | — |
+
+[BPQAXIPConfiguration]: https://www.cantab.net/users/john.wiseman/Documents/BPQAXIP%20Configuration.htm
+[BPQtoAGW]: https://www.cantab.net/users/john.wiseman/Documents/BPQtoAGW.htm
+[BPQHostModeEmulator]: https://www.cantab.net/users/john.wiseman/Documents/BPQ%20Host%20Mode%20Emulator.htm
+[BPQEthernet]: https://www.cantab.net/users/john.wiseman/Documents/BPQ%20Ethernet.htm
+[VirtualSerial]: https://www.cantab.net/users/john.wiseman/Documents/G8BPQ%20Virtual%20Serial%20Port%20Driver.htm
+[UsingPactor]: https://www.cantab.net/users/john.wiseman/Documents/Using%20Pactor.htm
+[UsingWINMOR]: https://www.cantab.net/users/john.wiseman/Documents/Using%20WINMOR.htm
+[AirmailtoWINMOR]: https://www.cantab.net/users/john.wiseman/Documents/AirmailtoWINMOR.htm
+
+### Terminal applications
+
+| Upstream page | Status | This site |
+|---------------|--------|-----------|
+| [BPQTerminal][BPQTerminal] | Pending | — |
+| [BPQTermTCP][BPQTermTCP] | Pending | — |
+| [BPQ OCX Programming][BPQOCX] | Pending | — |
+
+[BPQTerminal]: https://www.cantab.net/users/john.wiseman/Documents/BPQTerminal.htm
+[BPQTermTCP]: https://www.cantab.net/users/john.wiseman/Documents/BPQTermTCP.htm
+[BPQOCX]: https://www.cantab.net/users/john.wiseman/Documents/BPQ%20OCX%20Programming.htm
+
+### Changelogs
+
+| Upstream page | Status | This site |
+|---------------|--------|-----------|
+| [BPQ32 Node Changelog][NodeChangeLog] | Pending | — |
+| [Support Programs Changelog][SupportProgsChangeLog] | Pending | — |
+
+[NodeChangeLog]: https://www.cantab.net/users/john.wiseman/Documents/NodeChangeLog.html
+[SupportProgsChangeLog]: https://www.cantab.net/users/john.wiseman/Documents/SupportProgsChangeLog.html

--- a/docs/protocols/ax25.md
+++ b/docs/protocols/ax25.md
@@ -1,0 +1,8 @@
+# Ax25
+
+!!! warning "Stub page"
+    This page is a placeholder pending the rewrite-from-upstream
+    work tracked in [docs/plan.md](../plan.md).  John Wiseman's
+    original docs cover this material at
+    <https://www.cantab.net/users/john.wiseman/Documents/>.
+

--- a/docs/protocols/axip.md
+++ b/docs/protocols/axip.md
@@ -1,0 +1,162 @@
+# AX.25 over IP
+
+LinBPQ encapsulates AX.25 frames across three Internet
+transports: **AXIP** (IP protocol 93), **AXUDP** (UDP), and
+**AXTCP** (TCP).  In practice AXUDP is the most common because
+home routers and consumer ISPs handle UDP cleanly while protocol
+93 traffic gets dropped.  AXTCP exists for the case where the
+remote end can't accept inbound (e.g. NAT'd public Wi-Fi).
+
+!!! note "Upstream and source"
+    Re-presentation of John Wiseman's
+    [BPQAXIP Configuration page][upstream], adapted to the
+    LinBPQ-specific cfg-block form (the upstream describes the
+    Windows ``BPQAXIP.CFG`` external file; LinBPQ embeds the
+    same content inline between ``CONFIG`` and ``ENDPORT`` in
+    the main ``bpq32.cfg``).
+    Driver source: ``bpqaxip.c``.
+
+[upstream]: https://www.cantab.net/users/john.wiseman/Documents/BPQAXIP%20Configuration.htm
+
+## Quick example
+
+```ini
+PORT
+ ID=AXIP
+ DRIVER=BPQAXIP
+ QUALITY=200
+ MINQUAL=1
+ CONFIG
+ UDP 10093
+ BROADCAST NODES
+ MAP N0PEER 127.0.0.1 UDP 10094 B
+ENDPORT
+```
+
+This declares a port that:
+
+- Listens for AXUDP traffic on UDP/10093.
+- Treats `NODES` as a broadcast address (so NODES frames fan out
+  to mapped peers with the `B` flag set).
+- Routes any AX.25 frame addressed to a `N0PEER-*` callsign to
+  `127.0.0.1:10094`, and includes that peer in NODES broadcasts
+  (`B` flag).
+
+`QUALITY=200` and `MINQUAL=1` are required for NODES propagation
+to work — without them L3 (`L3Code.c`) skips this port for NODES
+emission.  See [issue #4][issue4] for the full diagnosis.
+
+[issue4]: https://github.com/M0LTE/linbpq/issues/4
+
+## CONFIG block keywords
+
+The keywords inside `CONFIG ... ENDPORT` are interpreted by
+`bpqaxip.c::ProcessConfig`.  All optional unless noted.
+
+### UDP
+
+```
+UDP <port>
+```
+
+Listen for AXUDP traffic on this UDP port.  Multiple `UDP` lines
+are allowed — one BPQAXIP port can listen on several UDP ports
+simultaneously, useful when joining several mesh networks
+(GB7RDG's production cfg uses this for OARC mesh ports).
+
+### MAP
+
+```
+MAP <callsign[-SSID]> <addr> [<protocol-options>] [B]
+```
+
+Routes outbound AX.25 frames addressed to `<callsign>` to the
+internet `<addr>`.  Without an explicit SSID, the entry matches
+*all* SSIDs of the call (wildcard match on the first 6 bytes).
+With an SSID it's an exact 7-byte match.
+
+`<protocol-options>` is one of:
+
+- *(absent)* — AXIP (raw IP protocol 93).  Rarely usable on the
+  open internet.
+- `UDP <port>` — AXUDP.  Sends to `<addr>:<port>`.  Pair with a
+  `UDP <port>` listener on the same port if you want
+  bidirectional.
+- `TCP-Master <port>` — AXTCP, this side originates the
+  connection.
+- `TCP-Slave <port>` — AXTCP, this side accepts the connection.
+
+The trailing `B` flag declares this peer as a broadcast
+recipient: NODES and ID frames fan out to it.  Without `B`, only
+unicast traffic is routed.
+
+### BROADCAST
+
+```
+BROADCAST <call>
+BROADCAST NODES
+BROADCAST ID
+```
+
+Declares an AX.25 call as a broadcast destination.  Frames
+addressed to this call are duplicated to every `MAP` entry that
+also has the `B` flag.  `BROADCAST NODES` is the standard
+configuration for participating in a NET/ROM network — without
+it your node won't tell its peers about its own dest list.
+
+### MHEARD
+
+```
+MHEARD ON
+```
+
+Update the L2 MH list from received frames on this port.  Off
+by default.
+
+### Other
+
+| Keyword | Effect | Source |
+|---------|--------|--------|
+| `KEEPALIVE <seconds>` (on a MAP) | Send keepalive packets at this interval to maintain NAT mappings | `bpqaxip.c::SendFrame` |
+| `AUTOADDMAP` | Auto-add MAP entries for previously unknown peers | `bpqaxip.c::AutoAddARP` |
+| `DONTCHECKSOURCECALL` | Skip the source-call resolution check on inbound frames | `bpqaxip.c::Checkifcanreply` |
+| `EXCLUDE <call>` | Drop frames from this call | — |
+
+## NODES propagation gotchas
+
+A working NET/ROM-over-AX/IP setup requires three cfg knobs and
+they're easy to miss:
+
+1. **Port-block `QUALITY=` non-zero** — without it `L3Code.c`
+   skips the port for NODES emission.
+2. **`BROADCAST NODES`** in the CONFIG block — without it
+   `NODES` isn't in `BroadcastAddresses` and frames addressed to
+   it aren't fanned out.
+3. **`B` flag** on every `MAP` line of a peer — without it
+   `bpqaxip.c::SendFrame` treats the peer as unicast-only and
+   skips broadcast deliveries.
+
+There's also a parser gotcha:
+
+> **The keyword=value form of `ROUTES:` is misparsed**
+> ([#12][issue12]) — separator-set inconsistency in
+> `config.c:1619`.  Use the comma form
+> `<call>,<qual>,<port>` instead.
+
+[issue12]: https://github.com/M0LTE/linbpq/issues/12
+
+## Test coverage
+
+| Test file | What it locks in |
+|-----------|------------------|
+| [`test_axip.py`][t_axip] | Basic two-instance bring-up, single-port AXIP, MAP routing |
+| [`test_axip_extras.py`][t_axip_extras] | Multi-`UDP` ports per block, `MHEARD ON`, `BROADCAST NODES`, `BROADCAST ID`, `MAP ... B` (broadcast flag), behavioural test that NODES actually fans out to mapped peers after `SENDNODES` |
+| [`test_two_instance.py`][t_two_inst] | Two-instance topology over AX/IP-UDP — NODES propagation + L4 uplink + `STOPROUTE`/`STARTROUTE`/`POLLNODES`/`SENDRIF` against the propagated route |
+| [`test_two_instance_bbs.py`][t_two_inst_bbs] | Cross-instance BBS post over AX/IP-UDP |
+| [`test_two_instance_bbs_forwarding.py`][t_fwd] | End-to-end FBB forwarding between two real BPQMail daemons over AX/IP-UDP |
+
+[t_axip]: https://github.com/M0LTE/linbpq/blob/master/tests/integration/test_axip.py
+[t_axip_extras]: https://github.com/M0LTE/linbpq/blob/master/tests/integration/test_axip_extras.py
+[t_two_inst]: https://github.com/M0LTE/linbpq/blob/master/tests/integration/test_two_instance.py
+[t_two_inst_bbs]: https://github.com/M0LTE/linbpq/blob/master/tests/integration/test_two_instance_bbs.py
+[t_fwd]: https://github.com/M0LTE/linbpq/blob/master/tests/integration/test_two_instance_bbs_forwarding.py

--- a/docs/protocols/fbb-forwarding.md
+++ b/docs/protocols/fbb-forwarding.md
@@ -1,0 +1,8 @@
+# Fbb forwarding
+
+!!! warning "Stub page"
+    This page is a placeholder pending the rewrite-from-upstream
+    work tracked in [docs/plan.md](../plan.md).  John Wiseman's
+    original docs cover this material at
+    <https://www.cantab.net/users/john.wiseman/Documents/>.
+

--- a/docs/protocols/index.md
+++ b/docs/protocols/index.md
@@ -1,0 +1,8 @@
+# Index
+
+!!! warning "Stub page"
+    This page is a placeholder pending the rewrite-from-upstream
+    work tracked in [docs/plan.md](../plan.md).  John Wiseman's
+    original docs cover this material at
+    <https://www.cantab.net/users/john.wiseman/Documents/>.
+

--- a/docs/protocols/kiss.md
+++ b/docs/protocols/kiss.md
@@ -1,0 +1,8 @@
+# Kiss
+
+!!! warning "Stub page"
+    This page is a placeholder pending the rewrite-from-upstream
+    work tracked in [docs/plan.md](../plan.md).  John Wiseman's
+    original docs cover this material at
+    <https://www.cantab.net/users/john.wiseman/Documents/>.
+

--- a/docs/protocols/netrom.md
+++ b/docs/protocols/netrom.md
@@ -1,0 +1,8 @@
+# Netrom
+
+!!! warning "Stub page"
+    This page is a placeholder pending the rewrite-from-upstream
+    work tracked in [docs/plan.md](../plan.md).  John Wiseman's
+    original docs cover this material at
+    <https://www.cantab.net/users/john.wiseman/Documents/>.
+

--- a/docs/subsystems/aprs.md
+++ b/docs/subsystems/aprs.md
@@ -1,0 +1,8 @@
+# Aprs
+
+!!! warning "Stub page"
+    This page is a placeholder pending the rewrite-from-upstream
+    work tracked in [docs/plan.md](../plan.md).  John Wiseman's
+    original docs cover this material at
+    <https://www.cantab.net/users/john.wiseman/Documents/>.
+

--- a/docs/subsystems/bbsmail.md
+++ b/docs/subsystems/bbsmail.md
@@ -1,0 +1,8 @@
+# Bbsmail
+
+!!! warning "Stub page"
+    This page is a placeholder pending the rewrite-from-upstream
+    work tracked in [docs/plan.md](../plan.md).  John Wiseman's
+    original docs cover this material at
+    <https://www.cantab.net/users/john.wiseman/Documents/>.
+

--- a/docs/subsystems/chat.md
+++ b/docs/subsystems/chat.md
@@ -1,0 +1,8 @@
+# Chat
+
+!!! warning "Stub page"
+    This page is a placeholder pending the rewrite-from-upstream
+    work tracked in [docs/plan.md](../plan.md).  John Wiseman's
+    original docs cover this material at
+    <https://www.cantab.net/users/john.wiseman/Documents/>.
+

--- a/docs/subsystems/index.md
+++ b/docs/subsystems/index.md
@@ -1,0 +1,8 @@
+# Index
+
+!!! warning "Stub page"
+    This page is a placeholder pending the rewrite-from-upstream
+    work tracked in [docs/plan.md](../plan.md).  John Wiseman's
+    original docs cover this material at
+    <https://www.cantab.net/users/john.wiseman/Documents/>.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,108 @@
+site_name: LinBPQ Documentation
+site_description: |
+  Re-presentation of John Wiseman G8BPQ's BPQ32 / LinBPQ documentation,
+  organised by user journey and fact-checked against the binary +
+  integration test suite.
+site_url: https://m0lte.github.io/linbpq/
+repo_url: https://github.com/M0LTE/linbpq
+repo_name: M0LTE/linbpq
+edit_uri: edit/master/docs/
+
+# Build into site/, not site/ inside docs/.  CI builds with --strict so
+# any dead nav link or missing page lands red.
+docs_dir: docs
+site_dir: site
+
+theme:
+  name: material
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.indexes
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.action.edit
+    - toc.follow
+  palette:
+    # Light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: blue grey
+      accent: indigo
+      toggle:
+        icon: material/toggle-switch
+        name: Switch to dark mode
+    # Dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: blue grey
+      accent: indigo
+      toggle:
+        icon: material/toggle-switch-off-outline
+        name: Switch to light mode
+  icon:
+    repo: fontawesome/brands/github
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+
+plugins:
+  - search
+
+# Page nav.  This grows as more pages are converted from upstream HTML.
+nav:
+  - Home: index.md
+  - Getting started:
+      - getting-started/index.md
+  - Configuration:
+      - Reference: configuration/reference.md
+      - bpq32.cfg keywords: configuration/bpq32-cfg-keywords.md
+  - Subsystems:
+      - subsystems/index.md
+      - BBS / mail (BPQMail): subsystems/bbsmail.md
+      - Chat node: subsystems/chat.md
+      - APRS gateway: subsystems/aprs.md
+  - Protocols and interfaces:
+      - protocols/index.md
+      - AX.25: protocols/ax25.md
+      - NET/ROM: protocols/netrom.md
+      - AX/IP over UDP: protocols/axip.md
+      - KISS: protocols/kiss.md
+      - FBB inter-BBS forwarding: protocols/fbb-forwarding.md
+  - Node prompt commands:
+      - node-commands.md
+  - Reference:
+      - test-coverage-audit.md
+      - mqtt-output.md
+  - Project:
+      - Plan: plan.md
+      - Contributing: project/contributing.md
+      - Upstream documentation: project/upstream.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/M0LTE/linbpq
+  generator: false


### PR DESCRIPTION
## Summary

Implements steps 1, 4, 5, 6 of the docs project in [docs/plan.md](https://github.com/M0LTE/linbpq/blob/master/docs/plan.md):

- **Step 1 (inventory):** [\`docs/project/upstream.md\`](https://github.com/M0LTE/linbpq/blob/docs-project/docs/project/upstream.md) catalogues every upstream page from [John Wiseman's site](https://www.cantab.net/users/john.wiseman/Documents/) with a per-page status (Rewritten / Partial / Pending).
- **Step 4 (MkDocs Material):** [\`mkdocs.yml\`](https://github.com/M0LTE/linbpq/blob/docs-project/mkdocs.yml) with theme, navigation tabs + sections, search, light/dark palette, code-copy + content-action edit, repo edit links.  Build outputs to \`site/\`.  Initial nav: Home, Getting started, Configuration, Subsystems (BBS / Chat / APRS), Protocols and interfaces (AX25, NET/ROM, AX/IP, KISS, FBB), Node prompt commands (existing), Reference (existing audit + MQTT docs), Project (plan + contributing + upstream).
- **Step 5 (CI):** [\`.github/workflows/docs.yml\`](https://github.com/M0LTE/linbpq/blob/docs-project/.github/workflows/docs.yml) builds the site on every PR with \`mkdocs build --strict\` so dead links and stale config land red, and deploys to GitHub Pages on push to master.
- **Step 6 (upstream credit):** [\`docs/index.md\`](https://github.com/M0LTE/linbpq/blob/docs-project/docs/index.md) and [\`docs/project/upstream.md\`](https://github.com/M0LTE/linbpq/blob/docs-project/docs/project/upstream.md) prominently link to John's pages and the cantab.net root.  This is positioned as a re-presentation, not a fork.

## First page rewrite

[\`docs/protocols/axip.md\`](https://github.com/M0LTE/linbpq/blob/docs-project/docs/protocols/axip.md) adapts the upstream [BPQAXIP Configuration](https://www.cantab.net/users/john.wiseman/Documents/BPQAXIP%20Configuration.htm) page to the LinBPQ-specific cfg-block form (the upstream describes the Windows \`BPQAXIP.CFG\` external file; LinBPQ embeds the same content inline between \`CONFIG\` and \`ENDPORT\` in the main \`bpq32.cfg\`).  Includes:

- Quick example matching what the integration tests use.
- Every CONFIG-block keyword (UDP, MAP, BROADCAST, MHEARD, plus KEEPALIVE / AUTOADDMAP / DONTCHECKSOURCECALL / EXCLUDE) with the source location that consumes it.
- The "three knobs needed for NODES propagation" gotcha plus the \`ROUTES:\` keyword=value parser bug (issue #12).
- A test-coverage table linking each lock-in test file.

## Stub pages

Other pages are stubs with consistent "pending rewrite" warnings pointing back at upstream.  Step 2 (reorganise IA) and step 3 (full Markdown rewrite) are the ongoing per-page work tracked in upstream.md's status column.

## Test plan

- [x] \`mkdocs build --strict\` passes
- [x] CI workflow validates with no syntax errors
- [x] Initial nav renders without dead links

## What this enables

The docs project becomes incremental: each future PR that rewrites another upstream page just adds/updates its target file and flips the row in upstream.md from Pending → Rewritten.  The CI catches regressions automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)