### PR TITLE
Fix RTTIncrement to include NeighbourSRTT

### DIFF
--- a/BPQINP3.c
+++ b/BPQINP3.c
@@ -373,7 +373,10 @@ VOID ProcessRTTReply(struct ROUTE * Route, struct _L3MESSAGEBUFFER * Buff)
 	else
 		Route->SRTT = ((Route->SRTT * 80)/100) + ((RTT * 20)/100);
 
-	Route->RTTIncrement = Route->SRTT / 2;		// Half for one way time.
+	if (Route->NeighbourSRTT)
+		Route->RTTIncrement = (Route->SRTT + Route->NeighbourSRTT) / 2;
+	else
+		Route->RTTIncrement = Route->SRTT / 2;
 
 	if (Route->RTTIncrement == 0)
 		Route->RTTIncrement = 1;

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -1,0 +1,21 @@
+CC      = gcc
+CFLAGS  = -Wall -Werror
+
+SRCS    = $(wildcard test_*.c)
+TESTS   = $(SRCS:.c=)
+
+.PHONY: test clean
+
+test: $(TESTS)
+	@fail=0; \
+	for t in $(TESTS); do \
+		echo "--- $$t ---"; \
+		./$$t || fail=1; \
+	done; \
+	exit $$fail
+
+test_%: test_%.c
+	$(CC) $(CFLAGS) -o $@ $<
+
+clean:
+	rm -f $(TESTS)

--- a/tests/unit/test_inp3_rttincrement.c
+++ b/tests/unit/test_inp3_rttincrement.c
@@ -1,0 +1,64 @@
+/*
+ * Unit test for INP3 RTTIncrement calculation.
+ *
+ * RTTIncrement should be the average of our SRTT and the neighbour's SRTT
+ * (see asmstrucs.h comment: "Average of Ours and Neighbours SRTT in 10 ms").
+ * When NeighbourSRTT is not yet known (zero), fall back to SRTT / 2.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+struct ROUTE
+{
+	int SRTT;
+	int NeighbourSRTT;
+	int RTTIncrement;
+};
+
+static void calculate_rttincrement(struct ROUTE *Route)
+{
+	if (Route->NeighbourSRTT)
+		Route->RTTIncrement = (Route->SRTT + Route->NeighbourSRTT) / 2;
+	else
+		Route->RTTIncrement = Route->SRTT / 2;
+}
+
+static int check(const char *label, int srtt, int neighbour_srtt, int expected)
+{
+	struct ROUTE r = { .SRTT = srtt, .NeighbourSRTT = neighbour_srtt };
+
+	calculate_rttincrement(&r);
+
+	if (r.RTTIncrement != expected)
+	{
+		fprintf(stderr, "FAIL %s: SRTT=%d NeighbourSRTT=%d expected=%d got=%d\n",
+			label, srtt, neighbour_srtt, expected, r.RTTIncrement);
+		return 1;
+	}
+
+	printf("PASS %s\n", label);
+	return 0;
+}
+
+int main(void)
+{
+	int failures = 0;
+
+	/* NeighbourSRTT unknown: fall back to SRTT / 2 */
+	failures += check("fallback_srtt_div2",       100, 0,   50);
+
+	/* Normal case: average of SRTT and NeighbourSRTT */
+	failures += check("average_different",         100, 200, 150);
+
+	/* Equal values: average equals either value */
+	failures += check("average_equal",             100, 100, 100);
+
+	/* Minimum non-zero values */
+	failures += check("minimum_nonzero",             1, 1,     1);
+
+	/* Both zero */
+	failures += check("both_zero",                   0, 0,     0);
+
+	return failures ? 1 : 0;
+}


### PR DESCRIPTION
Closes #59

## Summary

- **Bug:** `BPQINP3.c:376` computes `RTTIncrement = SRTT / 2` but the documented intent (asmstrucs.h:245) is "Average of Ours and Neighbours SRTT". The `NeighbourSRTT` field (set at line 960 when processing RTT messages) is never used in the calculation.
- **Impact:** INP3 link transit time is underestimated, not accounting for the remote node's processing/queuing delay. Route selection may prefer suboptimal paths.
- **Fix:** When `NeighbourSRTT` is available (non-zero), use `(SRTT + NeighbourSRTT) / 2`. Fall back to `SRTT / 2` when the neighbour hasn't reported its SRTT yet.
- **Severity:** Significant

Found by [net-sim INP3 analysis](https://github.com/packethacking/net-sim/blob/claude/netrom-analysis-optimization-QQMlP/analysis/LINBPQ-BUGS.md).

## Test plan

- [x] Unit test `tests/unit/test_inp3_rttincrement.c` added
  - NeighbourSRTT=0 falls back to SRTT/2
  - Both non-zero → average of both
  - Edge cases (equal values, minimum values, both zero)
- [ ] Verify no regressions in integration test suite

https://claude.ai/code/session_01PGQ7Jq6eH32nVguVCFXG9E