### PR TITLE
Remove dead unsigned < 0 comparison in ProcessRTTReply

### DIFF
--- a/BPQINP3.c
+++ b/BPQINP3.c
@@ -356,9 +356,9 @@ VOID ProcessRTTReply(struct ROUTE * Route, struct _L3MESSAGEBUFFER * Buff)
 	Route->Timeout = 0;			// Got Response
 	
 	sscanf(&Buff->L4DATA[6], "%u", &OrigTime);
-	RTT = GetTickCountINP3() - OrigTime;		// We work internally in mS
+	RTT = GetTickCountINP3() - OrigTime;		// 10ms units
 
-	if (RTT > 60000 || RTT < 0)
+	if (RTT > 60000)
 		return;					// Ignore if more than 60 secs (why ??)
 
 	if (RTT == 0)

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -1,0 +1,19 @@
+CC      = gcc
+CFLAGS  = -Wall -Werror
+
+SRCS    = $(wildcard test_*.c)
+TESTS   = $(SRCS:.c=)
+
+.PHONY: test clean
+
+test: $(TESTS)
+	@for t in $(TESTS); do \
+		echo "=== Running $$t ==="; \
+		./$$t || exit 1; \
+	done
+
+test_%: test_%.c
+	$(CC) $(CFLAGS) -o $@ $<
+
+clean:
+	rm -f $(TESTS)

--- a/tests/unit/test_inp3_unsigned_comparison.c
+++ b/tests/unit/test_inp3_unsigned_comparison.c
@@ -1,0 +1,68 @@
+/*
+ * test_inp3_unsigned_comparison.c
+ *
+ * Verify that the RTT bounds check in ProcessRTTReply correctly handles
+ * all uint32_t values.  The original code used:
+ *
+ *     if (RTT > 60000 || RTT < 0)
+ *
+ * Because RTT is uint32_t the "RTT < 0" arm is always false (unsigned
+ * values are never negative).  The simplified check is:
+ *
+ *     if (RTT > 60000)
+ *
+ * This also catches the wrap-around case (e.g. 0xFFFFFFFF) that the
+ * dead "< 0" comparison was presumably meant to cover.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+
+/* Mirrors the fixed bounds check from BPQINP3.c ProcessRTTReply. */
+static int rtt_is_rejected(uint32_t RTT)
+{
+    return RTT > 60000;
+}
+
+int main(void)
+{
+    int failures = 0;
+
+    /* Case 1: RTT = 0 -- valid, should NOT be rejected */
+    if (rtt_is_rejected(0)) {
+        fprintf(stderr, "FAIL: RTT=0 was rejected\n");
+        failures++;
+    }
+
+    /* Case 2: RTT = 1 -- valid, should NOT be rejected */
+    if (rtt_is_rejected(1)) {
+        fprintf(stderr, "FAIL: RTT=1 was rejected\n");
+        failures++;
+    }
+
+    /* Case 3: RTT = 60000 -- boundary, should NOT be rejected */
+    if (rtt_is_rejected(60000)) {
+        fprintf(stderr, "FAIL: RTT=60000 was rejected\n");
+        failures++;
+    }
+
+    /* Case 4: RTT = 60001 -- too high, should be rejected */
+    if (!rtt_is_rejected(60001)) {
+        fprintf(stderr, "FAIL: RTT=60001 was not rejected\n");
+        failures++;
+    }
+
+    /* Case 5: RTT = 0xFFFFFFFF -- wrapping case, caught by > 60000 */
+    if (!rtt_is_rejected(UINT32_C(0xFFFFFFFF))) {
+        fprintf(stderr, "FAIL: RTT=0xFFFFFFFF was not rejected\n");
+        failures++;
+    }
+
+    if (failures == 0) {
+        printf("All tests passed.\n");
+        return 0;
+    }
+
+    fprintf(stderr, "%d test(s) failed.\n", failures);
+    return 1;
+}


### PR DESCRIPTION
Closes #62

## Summary

- **Bug:** `BPQINP3.c:361` checks `if (RTT > 60000 || RTT < 0)` but `RTT` is `uint32_t`. The `< 0` comparison is always false for unsigned types — dead code that misleads readers.
- **Also:** Comment on line 359 says "We work internally in mS" but `GetTickCountINP3()` returns 10ms units.
- **Impact:** Minor — no functional impact, but the dead comparison masks the real invariant and may trigger compiler warnings.
- **Fix:** Remove `|| RTT < 0`, fix comment to say "10ms units".
- **Severity:** Minor

Found by [net-sim INP3 analysis](https://github.com/packethacking/net-sim/blob/claude/netrom-analysis-optimization-QQMlP/analysis/LINBPQ-BUGS.md).

## Test plan

- [x] Unit test `tests/unit/test_inp3_unsigned_comparison.c` added
  - RTT=0 (valid), RTT=60000 (boundary, valid), RTT=60001 (rejected)
  - RTT=0xFFFFFFFF (wrap-around, correctly rejected by >60000)
- [ ] Verify no regressions in integration test suite

https://claude.ai/code/session_01PGQ7Jq6eH32nVguVCFXG9E