### PR TITLE
Fix bare QTSM command crashing user session (NULL deref in QTSMCMD)

### DIFF
--- a/Cmd.c
+++ b/Cmd.c
@@ -6570,6 +6570,13 @@ VOID QTSMCMD(TRANSPORTENTRY * Session, char * Bufferptr, char * CmdTail, struct 
 
 	ptr = strtok_s(CmdTail, " ,\r", &context);
 
+	// strtok_s returns NULL when CmdTail has no token (bare QTSM).
+	// _stricmp(NULL, ...) and atoi(NULL) below would both crash; fall
+	// through to the "not a KISS port" error path with port == 0
+	// instead by treating an absent token as empty.
+	if (ptr == NULL)
+		ptr = "";
+
 	if (_stricmp(ptr, "HELP") == 0)
 	{
 		Bufferptr = Cmdprintf(Session, Bufferptr, "QTSM portno displays QTSM configuration info (if avaliable)\r", ptr);

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -1,0 +1,21 @@
+CC      = gcc
+CFLAGS  = -Wall -Werror
+
+SRCS    = $(wildcard test_*.c)
+TESTS   = $(SRCS:.c=)
+
+.PHONY: test clean
+
+test: $(TESTS)
+	@fail=0; \
+	for t in $(TESTS); do \
+		echo "--- $$t ---"; \
+		./$$t || fail=1; \
+	done; \
+	exit $$fail
+
+test_%: test_%.c
+	$(CC) $(CFLAGS) -o $@ $<
+
+clean:
+	rm -f $(TESTS)

--- a/tests/unit/test_qtsm_null_guard.c
+++ b/tests/unit/test_qtsm_null_guard.c
@@ -1,0 +1,92 @@
+/*
+ * Unit test for the QTSMCMD NULL-deref guard.
+ *
+ * In Cmd.c::QTSMCMD (around line 6571) the upstream 6.0.25.28 merge
+ * added a "QTSM HELP" subcommand by calling _stricmp() on the result
+ * of strtok_s() without a NULL check:
+ *
+ *     ptr = strtok_s(CmdTail, " ,\r", &context);
+ *     if (_stricmp(ptr, "HELP") == 0)   // ptr may be NULL
+ *
+ * When the user issues a bare "QTSM" (no arguments), CmdTail has no
+ * token, strtok_s() returns NULL, and _stricmp(NULL, ...) segfaults
+ * the user session.  atoi(NULL) on the next line is also undefined.
+ *
+ * The fix replaces a NULL token with an empty string, so the
+ * handler falls through to the existing "Error - Port 0 is not a
+ * KISS port" reply path without crashing.  This test exercises the
+ * corrected dispatch logic in isolation against the inputs that
+ * used to trigger the crash.
+ *
+ * See https://github.com/M0LTE/linbpq/issues/64.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+
+/* ---- Extracted dispatch logic (mirrors Cmd.c:6571..6585 + guard) ---- */
+
+static int qtsm_dispatch(char *cmd_tail)
+{
+    char *context = NULL;
+    char *ptr = strtok_r(cmd_tail, " ,\r", &context);
+    int port;
+
+    if (ptr == NULL)
+        ptr = "";
+
+    if (strcasecmp(ptr, "HELP") == 0)
+        return -1;                  /* HELP path */
+
+    port = atoi(ptr);
+    return port;                    /* falls through to PORT lookup */
+}
+
+/* ---- Test harness ------------------------------------------------ */
+
+static int failures = 0;
+
+static void check(const char *label, int expected, int actual)
+{
+    if (actual == expected) {
+        printf("PASS  %s: got %d\n", label, actual);
+    } else {
+        printf("FAIL  %s: expected %d, got %d\n", label, expected, actual);
+        failures++;
+    }
+}
+
+int main(void)
+{
+    char buf[64];
+
+    /* Bug repro: bare QTSM (empty CmdTail) used to NULL-deref via
+       _stricmp / atoi.  With the guard, dispatch returns port 0 and
+       the real handler emits "Error - Port 0 is not a KISS port". */
+    strcpy(buf, "");
+    check("bare QTSM", 0, qtsm_dispatch(buf));
+
+    /* All-whitespace tail produced NULL the same way. */
+    strcpy(buf, "   ");
+    check("whitespace-only tail", 0, qtsm_dispatch(buf));
+
+    /* HELP subcommand still reachable. */
+    strcpy(buf, "HELP");
+    check("HELP (uppercase)", -1, qtsm_dispatch(buf));
+
+    strcpy(buf, "help");
+    check("help (lowercase)", -1, qtsm_dispatch(buf));
+
+    /* Normal port number with trailing args still parses. */
+    strcpy(buf, "5 il2p only");
+    check("port 5 with args", 5, qtsm_dispatch(buf));
+
+    if (failures) {
+        printf("%d failures\n", failures);
+        return 1;
+    }
+    printf("OK\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Guard against `strtok_s` returning NULL in `Cmd.c::QTSMCMD` so bare `QTSM` no longer crashes the user session.
- Add a unit test covering the bare-command, whitespace-only, HELP and normal-port dispatch paths.

## Why

The 6.0.25.28 upstream merge introduced a `QTSM HELP` subcommand that calls `_stricmp(ptr, "HELP")` on the result of `strtok_s(CmdTail, " ,\r", ...)` without checking for NULL. Bare `QTSM` (no arguments) makes `strtok_s` return NULL; `_stricmp(NULL, …)` is undefined behaviour and segfaults on glibc, killing the user's telnet session.

`atoi(ptr)` on the next line has the same hazard.

## What

One-line fix: replace a NULL token with an empty string before the `_stricmp`/`atoi` calls. That restores the prior observable behaviour — bare `QTSM` falls through to `atoi("") == 0` and emits the existing `"Error - Port 0 is not a KISS port"` reply instead of crashing.

## Test plan

- [x] `make -C tests/unit test` — the new `test_qtsm_null_guard` exercises bare / whitespace / HELP / port-N inputs.
- [ ] Manual: telnet to a running linbpq, login, issue `QTSM\r`, confirm the session replies with `"Error - Port 0 is not a KISS port"` instead of going silent.
- [ ] Integration: `test_qtsm_without_port_rejected_cleanly` in `tests/integration/test_telnet_uz7ho.py` goes green again.

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)