### PR TITLE
docs: clarify RTTIncrement comment in asmstrucs.h

### DIFF
--- a/asmstrucs.h
+++ b/asmstrucs.h
@@ -242,7 +242,12 @@ typedef struct ROUTE
 	int RTT;				// Current	
 	int SRTT;				// Smoothed RTT
 	int NeighbourSRTT;		// Other End SRTT
-	int RTTIncrement;		// Average of Ours and Neighbours SRTT in 10 ms - smoothed neighbor transport time (SNTT) in spec
+	int RTTIncrement;		// Local SRTT in 10ms - smoothed neighbor transport time (SNTT) in spec.
+							// The spec describes this as the average of "our" and "neighbour's"
+							// round-trip measurements, but since neither end has a synchronised
+							// clock both measurements are full round-trips (out + back); the
+							// average adds no information vs the locally-measured SRTT, so we
+							// only use the local value.
 	int BCTimer;			// Time to next L3RTT Broadcast
 	int Timeout;			// Lost Response Timer
 	int Retries;			// Lost Response Count


### PR DESCRIPTION
## Summary

Re-word the comment on \`RTTIncrement\` in \`asmstrucs.h\` so it no longer suggests the field should be an arithmetic average of two SRTT values.

## Context

This is the cleanup half of PR #52 (which I'm closing as a false positive).

I had flagged the code as a bug because the comment said *"Average of Ours and Neighbours SRTT in 10 ms"* but the code only used the local SRTT. You [pointed out](https://github.com/M0LTE/linbpq/pull/52) that the comment is misleading, not the code:

> the average of the out and back times (because clocks aren't synchronised). So the average of the two will always be the same as the local time. As the two nodes can measure the RTT at different times the nodes may report them as different but using both doesn't improve routing decisions.

So this PR fixes the comment to match what the code correctly does.

## Test plan

- [x] No behaviour change — comment-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)